### PR TITLE
Add code climate add-on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,8 @@ deploy:
   app: Chess-app
   on:
     repo: TeamAlphaChess/Chess-app
+
+
+    addons: 
+      code_climate: 
+        repo_token: 62xBHrZMnWv6dfTcMAiq


### PR DESCRIPTION
Added this to travis.yml file so we can fully integrate code climate with Travis CI. This final step should get it working. Note that I did not create this as a secret key, which is probably a best practice. However, in an effort to get code climate up and running I just the default code climate instructions which did not include using a ENV variable to encrypt the token.
